### PR TITLE
Unified indentation of translation.js

### DIFF
--- a/js/translation.js
+++ b/js/translation.js
@@ -33,7 +33,7 @@ function translate() {
                     "ru": "Ru",
                     "de": "De",
                     "fr": "Fr",
-					"es": "Es"
+                    "es": "Es"
                 },
                 buttonType: "btn-default flag-button",
                 onSelect: function (value, element) {


### PR DESCRIPTION
Changed indentation of "es" from tabs to spaces for consistency.